### PR TITLE
Refactor: Centralize theme-specific logic and structure

### DIFF
--- a/src/components/app/app_component.rs
+++ b/src/components/app/app_component.rs
@@ -1,6 +1,6 @@
 use crate::auth::AuthContext;
 use crate::components::auth::AuthGuard;
-use crate::contexts::theme::ThemeProvider;
+use crate::components::themes::context::ThemeProvider;
 use dioxus::prelude::*;
 
 const MAIN_CSS: Asset = asset!("/assets/main.css");

--- a/src/components/atoms/mod.rs
+++ b/src/components/atoms/mod.rs
@@ -28,15 +28,7 @@ pub mod toggle;
 pub mod toggle_group;
 pub mod tooltip;
 
-// Theme wrapper utilities
-pub mod theme_wrappers;
-
 // Re-export components for easier imports
 pub use button::{Button, ButtonSize, ButtonVariant};
 pub use card::{Card, CardContent, CardFooter, CardHeader};
 pub use loader::{InlineLoader, Loader, LoaderSize, LoaderType, PageLoader};
-
-// Re-export theme-aware wrappers
-pub use theme_wrappers::{
-    ThemedButton, ThemedCard, ThemedInlineLoader, ThemedLoader, ThemedPageLoader,
-};

--- a/src/components/auth/auth_guard.rs
+++ b/src/components/auth/auth_guard.rs
@@ -1,7 +1,7 @@
 use crate::auth::{use_auth, use_auth_actions};
 use crate::components::app::Route;
 use crate::components::auth::{LoginScreen, LOADING_TEXT};
-use crate::contexts::theme::use_theme;
+use crate::components::themes::context::use_theme;
 use dioxus::prelude::*;
 
 #[component]

--- a/src/components/auth/login_screen.rs
+++ b/src/components/auth/login_screen.rs
@@ -1,7 +1,7 @@
 use crate::auth::use_auth_actions;
 use crate::components::atoms::{Button, ButtonVariant, Card, CardContent, CardHeader};
 use crate::components::auth::constants::*;
-use crate::contexts::theme::ThemeSwitcher;
+use crate::components::themes::context::ThemeSwitcher;
 use dioxus::prelude::*;
 
 #[component]

--- a/src/components/home/home_page.rs
+++ b/src/components/home/home_page.rs
@@ -1,5 +1,5 @@
 use crate::components::home::{Navigation, UserInfo};
-use crate::contexts::theme::ThemeSwitcher;
+use crate::components::themes::context::ThemeSwitcher;
 use dioxus::prelude::*;
 
 #[component]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod atoms;
+pub mod themes;
 // pub mod flashcard; // Commented out due to compilation errors
 // pub mod settings; // Commented out due to missing configs and contexts modules
 pub mod app;

--- a/src/components/synapse/synapse_component.rs
+++ b/src/components/synapse/synapse_component.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::action_executor::*;
 use crate::components::atoms::Button;
-use crate::contexts::theme::ThemeSwitcher;
+use crate::components::themes::context::ThemeSwitcher;
 use dioxus::prelude::*;
 use std::collections::HashMap;
 

--- a/src/components/themes/.gitkeep
+++ b/src/components/themes/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the directory is tracked by Git.

--- a/src/components/themes/context.rs
+++ b/src/components/themes/context.rs
@@ -112,6 +112,14 @@ pub struct Theme {
     pub animations: ThemeAnimations,
     pub decorative: ThemeDecorative,
     pub loaders: LoaderStyles,
+    pub component_texts: ComponentTexts,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentTexts {
+    pub button_loading_text: String,
+    pub loader_syncing_text: String,
+    pub loader_initializing_text: String,
 }
 
 impl Theme {
@@ -175,6 +183,11 @@ impl Theme {
                 primary_type: "hexagon".to_string(),
                 button_loader: "pulse".to_string(),
                 page_loader: "full-screen".to_string(),
+            },
+            component_texts: ComponentTexts {
+                button_loading_text: "PROCESSING...".to_string(),
+                loader_syncing_text: "SYNCING...".to_string(),
+                loader_initializing_text: "INITIALIZING...".to_string(),
             },
         }
     }

--- a/src/components/themes/mod.rs
+++ b/src/components/themes/mod.rs
@@ -1,0 +1,28 @@
+// Declare modules
+pub mod context;
+pub mod wrappers;
+
+// Re-export from context
+pub use context::{
+    use_theme, Theme, ThemeAnimationEffects, ThemeAnimations, ThemeBorderEffects, ThemeBorders,
+    ThemeBoxShadows, ThemeColors, ThemeComponentEffects, ThemeDecorative, ThemeEffects,
+    ThemeFontEffects, ThemeFonts, ThemeGeneralEffects, ThemeGlassEffects, ThemeGlowEffects,
+    ThemeGradientEffects, ThemeGridEffects, ThemeHoverEffects, ThemeLayout, ThemeLightingEffects,
+    ThemeMotionEffects, ThemeNeonEvangelion, ThemeNoiseEffects, ThemeOtherEffects,
+    ThemePatternEffects, ThemeScrollbarEffects, ThemeShadowEffects, ThemeSpacing, ThemeTypography,
+    ThemeVariant, ThemeProvider, ThemeSwitcher, ComponentTexts, LoaderStyles,
+    NeonEvangelionTheme, // This is a type alias for Theme
+    use_neon_theme, // This is a function alias for use_theme
+    NeonThemeProvider, // This is a component alias for ThemeProvider
+    CURRENT_THEME, // This is a GlobalSignal<Theme>
+    switch_theme, // This is a function
+};
+
+// Re-export from wrappers
+pub use wrappers::{
+    ThemedButton, ThemedButtonProps,
+    ThemedCard, ThemedCardProps,
+    ThemedLoader, ThemedLoaderProps, LoaderContext,
+    ThemedPageLoader, ThemedPageLoaderProps,
+    ThemedInlineLoader, ThemedInlineLoaderProps,
+};

--- a/src/components/themes/wrappers.rs
+++ b/src/components/themes/wrappers.rs
@@ -1,9 +1,9 @@
-use crate::contexts::theme::{use_theme, ThemeVariant};
+use crate::components::themes::context::{use_theme, ThemeVariant};
 use dioxus::prelude::*;
 
-use super::button::{Button, ButtonSize, ButtonVariant};
-use super::card::Card;
-use super::loader::{InlineLoader, Loader, LoaderType, PageLoader};
+use crate::components::atoms::button::{Button, ButtonSize, ButtonVariant};
+use crate::components::atoms::card::Card;
+use crate::components::atoms::loader::{InlineLoader, Loader, LoaderType, PageLoader};
 
 /// Theme-aware Button wrapper that automatically applies theme settings
 #[derive(Props, Clone, PartialEq)]
@@ -55,15 +55,17 @@ pub fn ThemedButton(props: ThemedButtonProps) -> Element {
         .unwrap_or(theme.decorative.corner_decorations);
 
     // Get theme-specific loading text if not provided
-    let loading_text = props.loading_text.clone().or_else(|| {
-        if *props.loading.read() {
-            Some(match theme.variant {
-                ThemeVariant::NeonEvangelion => "PROCESSING...".to_string(),
-            })
-        } else {
-            None
+    let loading_text = if props.loading_text.is_some() {
+        props.loading_text.clone()
+    } else if *props.loading.read() {
+        match theme.variant {
+            ThemeVariant::NeonEvangelion => Some(theme.component_texts.button_loading_text.clone()),
+            #[allow(unreachable_patterns)] // Allows for future themes not using this
+            _ => None,
         }
-    });
+    } else {
+        None
+    };
 
     rsx! {
         Button {
@@ -136,8 +138,8 @@ pub struct ThemedLoaderProps {
     loader_type_override: Option<LoaderType>,
 
     /// Size of the loader
-    #[props(default = super::loader::LoaderSize::Medium)]
-    size: super::loader::LoaderSize,
+    #[props(default = crate::components::atoms::loader::LoaderSize::Medium)]
+    size: crate::components::atoms::loader::LoaderSize,
 
     /// Optional loading text override
     #[props(default)]
@@ -156,7 +158,7 @@ pub enum LoaderContext {
 }
 
 impl LoaderContext {
-    fn get_theme_loader_type(self, theme: &crate::contexts::theme::Theme) -> LoaderType {
+    fn get_theme_loader_type(self, theme: &crate::components::themes::context::Theme) -> LoaderType {
         match self {
             LoaderContext::Primary => match theme.loaders.primary_type.as_str() {
                 "spinner" => LoaderType::Spinner,
@@ -196,11 +198,15 @@ pub fn ThemedLoader(props: ThemedLoaderProps) -> Element {
         .unwrap_or_else(|| props.context.get_theme_loader_type(&theme));
 
     // Get theme-specific loading text if not provided
-    let loading_text = props.text.clone().or_else(|| {
-        Some(match theme.variant {
-            ThemeVariant::NeonEvangelion => "SYNCING...".to_string(),
-        })
-    });
+    let loading_text = if props.text.is_some() {
+        props.text.clone()
+    } else {
+        match theme.variant {
+            ThemeVariant::NeonEvangelion => Some(theme.component_texts.loader_syncing_text.clone()),
+            #[allow(unreachable_patterns)] // Allows for future themes not using this
+            _ => None,
+        }
+    };
 
     rsx! {
         Loader {
@@ -242,11 +248,15 @@ pub fn ThemedPageLoader(props: ThemedPageLoaderProps) -> Element {
         .unwrap_or_else(|| LoaderContext::Page.get_theme_loader_type(&theme));
 
     // Get theme-specific loading text if not provided
-    let loading_text = props.text.clone().or_else(|| {
-        Some(match theme.variant {
-            ThemeVariant::NeonEvangelion => "INITIALIZING...".to_string(),
-        })
-    });
+    let loading_text = if props.text.is_some() {
+        props.text.clone()
+    } else {
+        match theme.variant {
+            ThemeVariant::NeonEvangelion => Some(theme.component_texts.loader_initializing_text.clone()),
+            #[allow(unreachable_patterns)] // Allows for future themes not using this
+            _ => None,
+        }
+    };
 
     rsx! {
         PageLoader {
@@ -266,8 +276,8 @@ pub struct ThemedInlineLoaderProps {
     loader_type_override: Option<LoaderType>,
 
     /// Size of the inline loader
-    #[props(default = super::loader::LoaderSize::Small)]
-    size: super::loader::LoaderSize,
+    #[props(default = crate::components::atoms::loader::LoaderSize::Small)]
+    size: crate::components::atoms::loader::LoaderSize,
 
     /// CSS class names to apply
     #[props(default)]


### PR DESCRIPTION
This commit addresses the issue of theme-related code potentially residing in atom components and ensures a centralized theme management approach.

Key changes:
- Introduced `ComponentTexts` within the `Theme` struct (`src/components/themes/context.rs`) to store theme-specific strings (e.g., loading messages for buttons and loaders).
- Updated `ThemedButton`, `ThemedLoader`, and `ThemedPageLoader` in `src/components/themes/wrappers.rs` to source these texts from the theme context, removing hardcoded values.
- Created a new directory `src/components/themes` to consolidate all theme-related Rust modules.
- Moved the theme context from `src/contexts/theme.rs` to `src/components/themes/context.rs`.
- Moved theme wrapper components from `src/components/atoms/theme_wrappers.rs` to `src/components/themes/wrappers.rs`.
- Updated all import paths across the project to reflect these new locations.
- Created `src/components/themes/mod.rs` to properly export theme context and wrapper functionalities.
- Reviewed all atom components in `src/components/atoms/` and confirmed they remain generic and free of theme-specific logic.
- Verified that the existing theme configuration (`LoaderStyles`, `LoaderType` enum) and CSS structure are sufficiently flexible to support diverse visual styles for components like loaders and buttons across different themes, as per the issue requirements.

These changes improve the modularity and maintainability of the theme system, making it easier to manage existing themes and add new ones with distinct visual characteristics.